### PR TITLE
separating admin

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,9 @@ RUST_LOG=info
 RUST_BACKTRACE=true
 
 # Ory url. This is either tunneled from the Ory site (using the Ory CLI) or selfhosted.
-ORY_URL=http://kratos:4434 # the administrative one for minos (port should not be publically exposed)
+# The difference can be relevant for local development, even though the admin url should redirect to the non-admin url when required.
+ORY_URL=http://kratos:4433
+ORY_ADMIN_URL=http://kratos:4434 # the administrative one for minos (port should not be publically exposed)
 BIND_ADDR=0.0.0.0:4000
 
 LABRINTH_API_URL="http://host.docker.internal:8000/v2" # will connect to Labrinth being run outside of the docker instance

--- a/minos/src/routes/callback.rs
+++ b/minos/src/routes/callback.rs
@@ -1,12 +1,11 @@
 use actix_web::web;
-use ory_client::apis::configuration::Configuration;
 use serde::{Deserialize, Serialize};
 
 use sqlx::pool;
 
 use crate::{
     routes::{ApiError, OryError},
-    util::{callback::CallbackError, oidc},
+    util::{callback::CallbackError, oidc, ory::AdminConfiguration},
 };
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -23,10 +22,10 @@ pub struct Payload {
 pub async fn settings_callback(
     payload: web::Json<Payload>,
     pool: web::Data<pool::Pool<sqlx::Postgres>>,
-    configuration: web::Data<Configuration>,
+    configuration: web::Data<AdminConfiguration>,
 ) -> Result<actix_web::HttpResponse, CallbackError> {
     let identity_with_credentials = ory_client::apis::identity_api::get_identity(
-        &configuration,
+        &configuration.0,
         &payload.identity_id,
         Some(vec!["oidc".to_string()]),
     )

--- a/minos/src/util/mod.rs
+++ b/minos/src/util/mod.rs
@@ -2,3 +2,4 @@ pub mod callback;
 pub mod env;
 pub mod fetch;
 pub mod oidc;
+pub mod ory;

--- a/minos/src/util/ory.rs
+++ b/minos/src/util/ory.rs
@@ -1,0 +1,36 @@
+use ory_client::apis::configuration::Configuration;
+use reqwest::Client;
+
+#[derive(Clone)]
+pub struct BasicConfiguration(pub Configuration);
+
+#[derive(Clone)]
+pub struct AdminConfiguration(pub Configuration);
+
+pub fn generate_basic_configuration() -> BasicConfiguration {
+    // Default Ory configuration
+    let configuration = Configuration {
+        api_key: None,
+        base_path: dotenvy::var("ORY_URL").unwrap(),
+        client: Client::new(),
+        basic_auth: None,
+        user_agent: Some("Modrinth Minos".to_string()),
+        oauth_access_token: None,
+        bearer_access_token: None,
+    };
+    BasicConfiguration(configuration)
+}
+
+pub fn generate_admin_configuration() -> AdminConfiguration {
+    // Default Ory configuration
+    let configuration = Configuration {
+        api_key: None,
+        base_path: dotenvy::var("ORY_ADMIN_URL").unwrap(),
+        client: Client::new(),
+        basic_auth: None,
+        user_agent: Some("Modrinth Minos Admin".to_string()),
+        oauth_access_token: None,
+        bearer_access_token: None,
+    };
+    AdminConfiguration(configuration)
+}


### PR DESCRIPTION
Separates admin configuration into a separate endpoint.
- This doesnt actually matter for a production case, where the administrative kratos endpoint (4434, used by Minos for admin tools) is able to redirect to the basic one (4434).
- However, locally, this redirection's url goes to the browser endpoint (which locally is 127.0.0.1:4433) which is not handled the same by the docker composition as might be initially expected

Also, fixes github id in labrinth not updating when oidc is connected *after* signup